### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:assert_identity, "~> 0.1.0"}
+    {:assert_identity, "~> 0.1.0", only: :test}
   ]
 end
 ```


### PR DESCRIPTION
AssertIdentity only needs to be in `test` env since it's just used for testing.